### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: .
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # zzp
-Something for working out costs and income
+Something for working out costs and income.
+
+## Deployment
+
+This repository is configured to publish the static site in `index.html`
+to GitHub Pages. When changes are pushed to the `main` branch, the
+`Deploy to GitHub Pages` workflow builds the site and deploys it to the
+`github-pages` environment. You can also trigger the workflow manually
+from the Actions tab using the **Run workflow** button.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to deploy the site to GitHub Pages
- document the automatic Pages deployment process in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dac1ecb6bc832ab4e799cb33cebd9e