### PR TITLE
Update Pages workflow to use the latest artifact action

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: .
 


### PR DESCRIPTION
## Summary
- update the GitHub Pages workflow to use `actions/upload-pages-artifact@v3` so it relies on the artifact v4 implementation

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dacc39a500832abe8f0400039c7fd4