### PR TITLE
Add favicon links for browser and iOS shortcuts

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" href="assets/favicon.png" type="image/png" />
+  <link rel="apple-touch-icon" href="assets/favicon.png" />
   <title>Course Pricing Calculator</title>
   <style>
     :root {


### PR DESCRIPTION
## Summary
- link the existing favicon into the document head for browsers
- expose the same asset as the Apple touch icon for iOS home screen saves

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daf0120748832ab33e72fbdd84badb