### PR TITLE
Fix concurrency group expression in pages preview workflow

### DIFF
--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -14,7 +14,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages-preview-${{ github.event.inputs.ref && replace(github.event.inputs.ref, '/', '-') || 'main' }}
+  group: pages-preview-${{ github.event.inputs.ref && github.event.inputs.ref || 'main' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- simplify the concurrency group expression in the Pages preview workflow to avoid unsupported functions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db42b8b624832abd79a765937810f2