### PR TITLE
Configure Pages deploy environment per event

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,7 +30,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment:
-      name: github-pages
+      name: ${{ github.event_name == 'pull_request' && 'preview' || 'github-pages' }}
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
## Summary
- set the deploy job environment to use the preview environment for pull requests while keeping github-pages for main pushes

## Testing
- act workflow -l *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68db4781a870832a8be59e2b24446ec1