### PR TITLE
Improve mobile layout and pricing emphasis

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,7 @@
 # TODO
 
 ## High Priority (UI/UX)
-- [ ] Ensure on mobile that the preset buttons appear above the form and reduce the large space that appears on mobile between the blog title and the form (see pic).
-- [ ] Swap the prominence of prices with and without VAT so the price including VAT is shown as the primary figure, with the VAT-exclusive amount secondary.
-- [ ] Consolidate the pricing table to display only the buffered price, omitting separate breakeven and buffered values.
+- [ ] _No open items._
 
 ## Medium Priority
 - [ ] Add an input field after "Students per Class" for "Lesson length (mins)" and use it to append hourly pricing (e.g., "(€XX/hr)") to each lesson price in the table.
@@ -11,3 +9,8 @@
 
 ## Low Priority
 - [ ] Auto-select light or dark mode by time of day but add a lock icon next to it the user can press to keep it on either. They can still manually switch the switch (they don't need to actually press the lock first) but it won't auto change if the lock is locked.
+
+## DONE
+- [x] Ensure on mobile that the preset buttons appear above the form and reduce the large space that appears on mobile between the blog title and the form (see pic). (2025-09-30)
+- [x] Swap the prominence of prices with and without VAT so the price including VAT is shown as the primary figure, with the VAT-exclusive amount secondary. (2025-09-30)
+- [x] Consolidate the pricing table to display only the buffered price, omitting separate breakeven and buffered values. (2025-09-30)

--- a/index.html
+++ b/index.html
@@ -598,7 +598,7 @@
       color: var(--text-muted);
     }
 
-    .price-line .vat {
+    .price-line .price-secondary {
       font-size: 0.8rem;
       color: var(--text-muted);
     }
@@ -654,6 +654,30 @@
 
       .theme-toggle {
         align-self: center;
+      }
+
+      .layout {
+        gap: 16px;
+      }
+
+      .controls {
+        gap: 16px;
+      }
+
+      .controls .presets {
+        order: 1;
+      }
+
+      .controls fieldset {
+        order: 2;
+      }
+
+      .controls .actions {
+        order: 3;
+      }
+
+      .controls .status-message {
+        order: 4;
       }
     }
 
@@ -839,12 +863,12 @@
           </div>
         </fieldset>
 
-        <div class="button-row" role="group" aria-label="Preset targets">
+        <div class="button-row presets" role="group" aria-label="Preset targets">
           <button type="button" class="secondary" data-preset="65k">Preset: 65k target</button>
           <button type="button" class="secondary" data-preset="100k">Preset: 100k target</button>
         </div>
 
-        <div class="button-row" role="group" aria-label="Actions">
+        <div class="button-row actions" role="group" aria-label="Actions">
           <button type="button" id="recalculate">Recalculate</button>
           <button type="button" id="download-csv" class="secondary">Download CSV</button>
         </div>
@@ -1238,35 +1262,26 @@
                     <div class="price-line">
                       <span class="price-label">Monthly net</span>
                       <strong>${monthlyDisplay}</strong>
-                      <span class="vat">Annual net ${annualDisplay}</span>
+                      <span class="price-secondary">Annual net ${annualDisplay}</span>
                     </div>
                     <div class="price-line buffered">
                       <span class="price-label">Monthly net with ${formattedBuffer}% shortfall</span>
                       <strong>${bufferedMonthlyDisplay}</strong>
-                      <span class="vat">Annual net ${bufferedAnnualDisplay}</span>
+                      <span class="price-secondary">Annual net ${bufferedAnnualDisplay}</span>
                     </div>
                   </div>
                 </td>
               `;
               }
 
-              const breakEvenExVat = formatCurrency(symbol, col.breakEven.priceExVat);
-              const breakEvenInclVat = formatCurrency(symbol, col.breakEven.priceInclVat);
               const bufferedExVat = formatCurrency(symbol, col.buffered.priceExVat);
               const bufferedInclVat = formatCurrency(symbol, col.buffered.priceInclVat);
               return `
                 <td>
-                  <div class="price-pair">
-                    <div class="price-line">
-                      <span class="price-label">Break-even</span>
-                      <strong>${breakEvenExVat}</strong>
-                      <span class="vat">incl VAT ${breakEvenInclVat}</span>
-                    </div>
-                    <div class="price-line buffered">
-                      <span class="price-label">Buffered +${formattedBuffer}%</span>
-                      <strong>${bufferedExVat}</strong>
-                      <span class="vat">incl VAT ${bufferedInclVat}</span>
-                    </div>
+                  <div class="price-line buffered">
+                    <span class="price-label">Buffered +${formattedBuffer}%</span>
+                    <strong>${bufferedInclVat}</strong>
+                    <span class="price-secondary">ex VAT ${bufferedExVat}</span>
                   </div>
                 </td>
               `;
@@ -1498,32 +1513,18 @@
           const priceInclVat = priceExVat * (1 + vatRate);
           const bufferedInclVat = bufferedExVat * (1 + vatRate);
 
-          const roundedBreakEvenExVat = Math.round(priceExVat);
-          const roundedBreakEvenInclVat = Math.round(priceInclVat);
           const roundedBufferedExVat = Math.round(bufferedExVat);
           const roundedBufferedInclVat = Math.round(bufferedInclVat);
 
           row.columns.push({
             classesPerWeek: column.classesPerWeek,
             classesPerYear: column.classesPerYear,
-            breakEven: {
-              priceExVat: roundedBreakEvenExVat,
-              priceInclVat: roundedBreakEvenInclVat
-            },
             buffered: {
               priceExVat: roundedBufferedExVat,
               priceInclVat: roundedBufferedInclVat
             }
           });
 
-          latestResults.push({
-            variant: 'Break-even',
-            students,
-            classesPerWeek: column.classesPerWeek,
-            classesPerYear: Math.round(column.classesPerYear),
-            priceExVat: roundedBreakEvenExVat,
-            priceInclVat: roundedBreakEvenInclVat
-          });
           latestResults.push({
             variant: `Buffered +${bufferPercent}%`,
             students,
@@ -1678,14 +1679,14 @@
           ].join(',');
         });
       } else {
-        header = 'Variant,Students,Classes per week,Classes per year,Price ex VAT,Price incl VAT';
+        header = 'Variant,Students,Classes per week,Classes per year,Price incl VAT,Price ex VAT';
         rows = latestResults.map(entry => [
           entry.variant,
           entry.students,
           entry.classesPerWeek,
           entry.classesPerYear,
-          entry.priceExVat,
-          entry.priceInclVat
+          entry.priceInclVat,
+          entry.priceExVat
         ].join(','));
       }
 
@@ -1702,7 +1703,7 @@
       URL.revokeObjectURL(url);
       controls.statusMessage.textContent = latestResultsMode === PRICING_MODE_LESSON
         ? 'CSV download started. File lists monthly and annual net income for each combination.'
-        : 'CSV download started. File contains both break-even and buffered rows.';
+        : 'CSV download started. File lists buffered prices including and excluding VAT.';
       setTimeout(() => {
         controls.statusMessage.textContent = '';
       }, 2500);


### PR DESCRIPTION
## Summary
- reorder preset controls on narrow screens to reduce the mobile gap under the header
- highlight buffered VAT-inclusive prices as the primary figure while keeping VAT-exclusive values secondary
- update the export messaging and TODO log to reflect the new single buffered price presentation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbc7a73e64832a9770abac7ff1e902