### PR TITLE
Adjust mobile header text flex sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -649,6 +649,7 @@
       }
 
       .header-text {
+        flex: 1 1 auto;
         text-align: center;
       }
 


### PR DESCRIPTION
## Summary
- allow the header text column to shrink to its content height on narrow screens so the toggle sits closer to the intro copy

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd5d68e1f4832aaa0e354fa6b85a4b