### PR TITLE
Add custom 404 page for cleaned-up previews

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Preview Not Found · Course Pricing Calculator</title>
+  <link rel="icon" href="assets/favicon.png" type="image/png" />
+  <link rel="apple-touch-icon" href="assets/favicon.png" />
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg-gradient: radial-gradient(circle at top left, #1e2330, #10131c 55%, #0a0c12 100%);
+      --card-bg: rgba(20, 24, 35, 0.9);
+      --card-border: rgba(255, 255, 255, 0.08);
+      --card-shadow: 0 24px 48px rgba(0, 0, 0, 0.5);
+      --accent: #4da3ff;
+      --text-primary: #f5f7fb;
+      --text-muted: #b1b7c7;
+      --button-bg: #f1f5ff;
+      --button-color: #0c111d;
+      --button-shadow: rgba(0, 0, 0, 0.3);
+      --link-muted: rgba(241, 245, 255, 0.25);
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: var(--bg-gradient);
+      color: var(--text-primary);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: clamp(24px, 4vw, 48px);
+    }
+
+    main {
+      width: min(680px, 100%);
+    }
+
+    .card {
+      background: var(--card-bg);
+      border: 1px solid var(--card-border);
+      border-radius: 24px;
+      padding: clamp(32px, 5vw, 56px);
+      box-shadow: var(--card-shadow);
+      display: flex;
+      flex-direction: column;
+      gap: clamp(16px, 2vw, 24px);
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(2.25rem, 4vw, 3rem);
+      letter-spacing: -0.02em;
+    }
+
+    p {
+      margin: 0;
+      font-size: clamp(1rem, 1.8vw, 1.15rem);
+      line-height: 1.6;
+      color: var(--text-muted);
+    }
+
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: clamp(8px, 2vw, 16px);
+    }
+
+    a.button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      padding: 0.85rem 1.35rem;
+      background: var(--button-bg);
+      color: var(--button-color);
+      border-radius: 999px;
+      font-weight: 600;
+      text-decoration: none;
+      box-shadow: 0 16px 32px var(--button-shadow);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    a.button:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 22px 36px rgba(0, 0, 0, 0.35);
+    }
+
+    .muted-link {
+      color: var(--link-muted);
+      text-decoration: none;
+      font-size: 0.95rem;
+    }
+
+    .muted-link:hover {
+      text-decoration: underline;
+    }
+
+    @media (max-width: 480px) {
+      .card {
+        border-radius: 20px;
+      }
+
+      a.button {
+        width: 100%;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="card" role="alert">
+      <h1>Preview no longer available</h1>
+      <p>
+        The preview you are looking for has already been cleaned up after its pull request
+        was merged or closed. The production calculator is still live, and you can reopen a
+        new preview by pushing fresh changes to a pull request.
+      </p>
+      <div class="actions">
+        <a class="button" href="/">Go to the live calculator</a>
+        <a class="muted-link" href="https://github.com/pulls">View your pull requests</a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a branded 404 page that explains preview deployments may have been cleaned up
- provide quick links back to the live calculator and to pull requests

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68dd7490fb70832a92f38731821bbf07