### PR TITLE
Include 404 page in Pages artifact

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,6 +27,7 @@ jobs:
           rm -rf dist
           mkdir -p dist
           cp index.html dist/
+          cp 404.html dist/
           cp -R assets dist/
 
       - name: Upload build artifact


### PR DESCRIPTION
## Summary
- ensure the GitHub Pages build copies 404.html into the dist directory so the error page is deployed with the site

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dda99d6464832a9281dcdb53148515