### PR TITLE
Add .nojekyll for GitHub Pages

### DIFF
--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+# Prevent GitHub Pages from running Jekyll


### PR DESCRIPTION
## Summary
- add a .nojekyll marker so GitHub Pages serves raw repository files such as README.md

## Testing
- python -m http.server 8000
- curl -I http://127.0.0.1:8000/README.md

------
https://chatgpt.com/codex/tasks/task_e_68ddac513c18832a9e34cce998d231a1