### PR TITLE
Ensure preview workflow runs with pull_request_target

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,9 +2,13 @@ name: Pages (prod + previews)
 
 on:
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - work
+  pull_request_target:
+    branches:
+      - main
+      - work
   workflow_dispatch:
 
 concurrency:
@@ -20,7 +24,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository (push/workflow dispatch)
+        if: github.event_name != 'pull_request_target'
+        uses: actions/checkout@v4
+
+      - name: Checkout pull request head
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Prepare site content
         run: |
@@ -61,12 +74,15 @@ jobs:
 
   deploy_preview:
     needs: build
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - id: pr
         run: echo "dir=previews/pr-${{ github.event.number }}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- trigger preview deployments using pull_request_target so workflow runs for forked pull requests with write permissions
- check out the pull request head commit explicitly when running build and preview jobs to use the proposed changes

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68f6a6c888d0832aab241b147e055630