### PR TITLE
Add pull_request_target handling to Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
       - work
+  pull_request_target:
+    branches:
+      - main
+      - work
   workflow_dispatch:
 
 concurrency:
@@ -24,7 +28,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        if: github.event_name != 'pull_request_target'
+        uses: actions/checkout@v4
+
+      - name: Checkout pull request head
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare site content
         run: |
@@ -65,12 +79,23 @@ jobs:
 
   deploy_preview:
     needs: build
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        if: github.event_name != 'pull_request_target'
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Checkout pull request head
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - id: pr
         run: echo "dir=previews/pr-${{ github.event.number }}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- trigger the Pages workflow on pull_request_target events for main and work
- checkout the pull request head when builds and previews run under pull_request_target

## Testing
- not run (workflow updates only)

------
https://chatgpt.com/codex/tasks/task_e_68f6be748280832a87714789957df987